### PR TITLE
Minor fixes

### DIFF
--- a/thunderstorm/src/main/frontend/components/GenericDropDown/GenericDropDownV3.tsx
+++ b/thunderstorm/src/main/frontend/components/GenericDropDown/GenericDropDownV3.tsx
@@ -170,6 +170,7 @@ export class GenericDropDownV3<Proto extends DBProto<any>, T extends Proto['dbTy
 			selected={this.state.selected}
 			onNoMatchingSelectionForString={this.props.onNoMatchingSelectionForString}
 			onSelected={this.props.onSelected}
+			noOptionsRenderer={this.props.noOptionsRenderer}
 			caret={this.props.caret}
 			selectedItemRenderer={this.props.selectedItemRenderer}
 			boundingParentSelector={this.props.boundingParentSelector}

--- a/thunderstorm/src/main/frontend/components/TS_PropRenderer/TS_PropRenderer.tsx
+++ b/thunderstorm/src/main/frontend/components/TS_PropRenderer/TS_PropRenderer.tsx
@@ -35,7 +35,10 @@ const TS_PropRenderer_Horizontal = (props: Props_PropRendererHorizontal) => {
 	}
 
 	return <_LinearComponent {..._props} className={className}>
-		<div className={'ts-prop-renderer__label'}>{resolveContent(label)}</div>
+		<div className={'ts-prop-renderer__label'}>
+			{resolveContent(label)}
+			{props.error && <div className={'ts-prop-renderer__error'}>{props.error}</div>}
+		</div>
 		{props.children}
 	</_LinearComponent>;
 };
@@ -44,7 +47,10 @@ const TS_PropRenderer_Vertical = (props: Props_PropRenderer) => {
 	const className = _className('ts-prop-renderer vertical', props.disabled && 'disabled', props.className);
 	const {label, error, ..._props} = props;
 	return <LL_V_L {..._props} className={className}>
-		<div className={'ts-prop-renderer__label'}>{resolveContent(label)}</div>
+		<div className={'ts-prop-renderer__label'}>
+			{resolveContent(label)}
+			{props.error && <div className={'ts-prop-renderer__error'}>{props.error}</div>}
+		</div>
 		{props.children}
 	</LL_V_L>;
 };

--- a/ts-common/src/main/db/consts.ts
+++ b/ts-common/src/main/db/consts.ts
@@ -2,3 +2,4 @@ export const Const_UniqueKey = '_id';
 export const Const_UniqueKeys = [Const_UniqueKey];
 
 export const DefaultDBVersion = '1.0.0';
+export const DefaultNewItemId = '##NEWITEM##';


### PR DESCRIPTION
- GenericDropDownV3 now passes the "noOptionsRenderer" prop to TS_Dropdown.
- Add error indication (with the existing "error" prop) to TS_PropRenderer in the horizontal and vertical view modes.
- Added new const "DefaultNewItemId"