### PR TITLE
Fix vulnerabilities fix

### DIFF
--- a/app-backend/__package.json
+++ b/app-backend/__package.json
@@ -53,7 +53,6 @@
     "firebase-functions-test": "^0.1.6",
     "@slack/web-api": "?",
     "body-parser": "^1.18.3",
-    "file-type": "^16.3.0",
     "compression": "^1.7.4",
     "debug": "^3.1.0",
     "express": "?",

--- a/app-frontend/__package.json
+++ b/app-frontend/__package.json
@@ -83,7 +83,7 @@
     "util": "^0.12.4",
     "webpack": "^5.64.1",
     "webpack-cli": "^4.9.1",
-    "webpack-dev-server": "^4.5.0",
+    "webpack-dev-server": "^5.2.3",
     "webpack-manifest-plugin": "^4.0.2",
     "write-file-webpack-plugin": "^4.5.1"
   },

--- a/app-frontend/__package.json
+++ b/app-frontend/__package.json
@@ -50,7 +50,6 @@
     "file-loader": "^6.2.0",
     "mic-recorder-to-mp3": "^2.2.2",
     "moment": "?",
-    "autoprefixer": "^9.1.5",
     "browserify-zlib": "^0.2.0",
     "buffer": "^6.0.3",
     "chart.js": "^2.9.4",

--- a/app-frontend/__package.json
+++ b/app-frontend/__package.json
@@ -65,7 +65,6 @@
     "html-beautify-webpack-plugin": "^1.0.5",
     "html-loader": "^3.0.1",
     "html-webpack-plugin": "^5.5.0",
-    "imagemin": "^8.0.1",
     "mini-css-extract-plugin": "^2.4.5",
     "qs": "^6.6.0",
     "react": "?",

--- a/github/backend/__package.json
+++ b/github/backend/__package.json
@@ -23,9 +23,7 @@
     "@nu-art/thunderstorm-backend": "?",
     "@nu-art/thunderstorm-shared": "?",
     "@nu-art/ts-common": "?",
-    "@octokit/plugin-paginate-rest": "2.2.1",
-    "@octokit/rest": "18.0.9",
-    "@octokit/types": "^5.5.0",
+    "@octokit/rest": "21.1.1",
     "jsonwebtoken": "^9.0.0"
   },
   "devDependencies": {

--- a/github/backend/src/main/modules/ModuleBE_Github.ts
+++ b/github/backend/src/main/modules/ModuleBE_Github.ts
@@ -64,7 +64,7 @@ export class GithubModule_Class
 		const installations = await client.apps.listInstallations();
 		// Get installations that match GIT_OWNER.
 		const filteredInstallations = installations.data.filter((installation) => {
-			return installation.account.login === this.config.gitOwner;
+			return installation.account?.login === this.config.gitOwner;
 		});
 
 		// Handle/log cases where the number of matching installations of the Github App is different than one.
@@ -130,7 +130,7 @@ export class GithubModule_Class
 		if (Array.isArray(contents.data)) {
 			throw new BadImplementationException('Invalid response of method repos.getContent');
 		}
-		if (!contents || !contents.data || !contents.data.content) {
+		if (!contents || !contents.data || !('content' in contents.data) || !contents.data.content) {
 			throw new Exception('Failed to get file contents from Github');
 		}
 

--- a/github/backend/src/main/modules/ModuleBE_Github.ts
+++ b/github/backend/src/main/modules/ModuleBE_Github.ts
@@ -17,7 +17,6 @@
  */
 import {BadImplementationException, currentTimeMillis, Exception, JwtTools, Minute, Module} from '@nu-art/ts-common';
 import {Octokit, RestEndpointMethodTypes} from '@octokit/rest';
-import {OctokitResponse, ReposGetContentResponseData} from '@octokit/types';
 import * as path from 'path';
 
 
@@ -103,7 +102,7 @@ export class GithubModule_Class
 		const token = await this.getGithubInstallationToken();
 		const client: Octokit = this.createClient(token);
 
-		let contents: OctokitResponse<RestEndpointMethodTypes['repos']['getContent']['response']['data']>;
+		let contents: RestEndpointMethodTypes['repos']['getContent']['response'];
 
 		try {
 			contents = await client.repos.getContent(
@@ -158,7 +157,7 @@ export class GithubModule_Class
 
 	private async getFileBySha(client: Octokit, repo: string, filePath: string, branch: string) {
 		const parentPath = path.dirname(filePath);
-		let parentDirectoryResponse: OctokitResponse<RestEndpointMethodTypes['repos']['getContent']['response']['data']>;
+		let parentDirectoryResponse: RestEndpointMethodTypes['repos']['getContent']['response'];
 		try {
 			const request = {
 				owner: this.config.gitOwner,
@@ -273,7 +272,7 @@ export class GithubModule_Class
 	 *
 	 * This API has an upper limit of 1,000 files for a directory.
 	 */
-	async listDirectoryContents(repo: string, branch: string, _path: string): Promise<ReposGetContentResponseData | undefined> {
+	async listDirectoryContents(repo: string, branch: string, _path: string): Promise<RestEndpointMethodTypes['repos']['getContent']['response']['data'] | undefined> {
 		const token = await this.getGithubInstallationToken();
 		const client: Octokit = this.createClient(token);
 


### PR DESCRIPTION
1. Remove unused autoprefixer (e47f8bf) Eliminates transitive postcss@7.0.39 vulnerability (#7). The package was declared but never imported — the project already uses postcss@8.5.10 via webpack/sass.

2. Upgrade @octokit/rest v18 → v21 (aa71e83 + a113f88) Resolves 3 ReDoS vulnerabilities in transitive deps: @octokit/request-error@2.1.0, @octokit/request@5.6.3, and @octokit/plugin-paginate-rest@2.2.1 (Dependabot #14, #15, #16). The paginate plugin is now bundled in v21, so the direct dependency was removed. TypeScript errors from the v21 type changes were fixed in a follow-up commit.

3. Remove unused imagemin and file-type (96b1a2a) Neither package is imported in any source file. Removing them eliminates the transitive file-type@16.5.4 vulnerability (Dependabot #111 — infinite loop in ASF parser on malformed input).

4. Upgrade webpack-dev-server v4 → v5.2.3 (6765825) Fixes CVE-2025-30359 and CVE-2025-30360 (source code theft via malicious websites). No config changes required — existing devServer options are already v5-compatible.

