### PR TITLE
logger: add disableColors flag to LogClient_MemBuffer

### DIFF
--- a/logger/src/main/LogClient_MemBuffer.ts
+++ b/logger/src/main/LogClient_MemBuffer.ts
@@ -51,6 +51,8 @@ export class LogClient_MemBuffer
 	extends LogClient_BaseRotate {
 	/** If true, preserves natural colors in log output (disables ANSI color codes) */
 	private keepNaturalColors = false;
+	/** If true, no ANSI color codes are added to the log at all (plain text output) */
+	private colorsDisabled = false;
 	/** Array of log buffers, where index 0 is the current buffer */
 	readonly buffers: string[] = [''];
 	/** Optional callback invoked when a log is appended */
@@ -105,9 +107,9 @@ export class LogClient_MemBuffer
 	 * @returns Formatted log string
 	 */
 	protected processLogMessage(level: LogLevel, bold: boolean, prefix: string, toLog: LogParam[]) {
-		const color = getColor(level, bold);
+		const color = this.colorsDisabled ? '' : getColor(level, bold);
 		let log = _logger_convertLogParamsToStrings(toLog).join(' ');
-		const linePrefix = `${color}${prefix}${this.keepNaturalColors ? NoColor : ''}`;
+		const linePrefix = `${color}${prefix}${!this.colorsDisabled && this.keepNaturalColors ? NoColor : ''}`;
 
 		if (this.logTransformer)
 			log = this.logTransformer(log);
@@ -155,5 +157,20 @@ export class LogClient_MemBuffer
 	 */
 	public keepLogsNaturalColors(keepNaturalColors = true) {
 		this.keepNaturalColors = keepNaturalColors;
+	}
+
+	/**
+	 * Controls whether ANSI color codes are added to the stored logs.
+	 *
+	 * When disabled, logs are stored as plain text with no color escape sequences -
+	 * useful when the buffer is consumed by something other than a terminal (e.g. shipped
+	 * in a bug report or written to a plain-text sink).
+	 *
+	 * @param disableColors - If true, no ANSI color codes are added. Defaults to true.
+	 * @returns This instance for method chaining
+	 */
+	public disableColors(disableColors = true) {
+		this.colorsDisabled = disableColors;
+		return this;
 	}
 }


### PR DESCRIPTION
## What

Adds a `disableColors()` setter to `LogClient_MemBuffer`. When enabled, no ANSI color escape codes are written to the stored buffers, keeping the logs as plain text.

```ts
new LogClient_MemBuffer('advisor', 2, size).disableColors();
```

## Why

The memory buffer is being consumed outside of a terminal (attached to advisor bug reports). Previously the level color was always emitted into the buffer, so consumers had to strip ANSI codes after the fact — and the colored prefix couldn't be cleanly removed via a `logTransformer` (which only runs on the log body). Not emitting the codes in the first place is the clean fix.

## Notes

- Defaults to `false` — existing behavior is unchanged for all current consumers.
- `keepLogsNaturalColors` is unaffected; when colors are disabled the natural-colors reset is also skipped since there's no color to reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)