### PR TITLE
fix(sync-manager): module readiness / artifact-sync hardening

### DIFF
--- a/thunderstorm/frontend/src/main/modules/sync-manager/ModuleFE_SyncManager.ts
+++ b/thunderstorm/frontend/src/main/modules/sync-manager/ModuleFE_SyncManager.ts
@@ -279,8 +279,14 @@ export class ModuleFE_SyncManager_Class
 			throw new MUSTNeverHappenException(`Trying perform NoSync without an existing rtModule: ${data.dbKey}`);
 
 		//If the cache is already loaded no need to reload
-		if (rtModule.getDataStatus() === DataStatus.ContainsData)
+		if (rtModule.getDataStatus() === DataStatus.ContainsData && rtModule.cache.all().length > 0)
 			return;
+
+		// ContainsData with an empty MemCache means a prior step marked the module ready
+		// without hydrating the cache (e.g. cache cleared with no status change). Don't
+		// trust the status — fall through and reload from IDB.
+		if (rtModule.getDataStatus() === DataStatus.ContainsData)
+			rtModule.logWarning(`ContainsData with empty MemCache — reloading from IDB: ${rtModule.dbDef.dbKey}`);
 
 		this.currentlySyncingModules.push({module: rtModule, syncId: this.generateSyncRequestId()});
 
@@ -343,6 +349,14 @@ export class ModuleFE_SyncManager_Class
 				rtModule.logVerbose(`Cleaning IDB: ${rtModule.dbDef.dbKey}`);
 				await rtModule.IDB.clear(); // Also sets the module's data status to NoData.
 			}
+			// Flip to UpdatingData BEFORE emptying the cache. When cleanIDBOnFullSync is
+			// false the status otherwise stays ContainsData across the whole round-trip, so
+			// the terminal setDataStatus(ContainsData) below is a no-op that dispatches
+			// nothing — AwaitModules never re-derives and components keep rendering the
+			// now-empty cache. The transition also makes the final ContainsData a real
+			// change in both branches. (setDataStatus already dispatches via syncDispatcher.)
+			rtModule.logVerbose(`Firing event (DataStatus.UpdatingData): ${rtModule.dbDef.dbKey}`);
+			rtModule.setDataStatus(DataStatus.UpdatingData);
 			rtModule.logVerbose(`Cleaning Cache: ${rtModule.dbDef.dbKey}`);
 			rtModule.cache.clear();
 

--- a/thunderstorm/frontend/src/main/modules/sync-manager/ModuleFE_SyncManager_CSV.ts
+++ b/thunderstorm/frontend/src/main/modules/sync-manager/ModuleFE_SyncManager_CSV.ts
@@ -49,10 +49,9 @@ export class ModuleFE_SyncManager_CSV_Class
 
 					complete: async () => {
 						try {
-							// Any parse error fails the whole sync — surfaced via the session
-							// error UI (ComponentValidateSessionV2) and clears the version key
-							// (ModuleFE_AdvisorSync.syncSnapshot catch), rather than silently
-							// committing partial data.
+							// Any parse error rejects the whole sync so the caller can react to
+							// the failure, rather than silently committing partial data and
+							// resolving as if the sync succeeded.
 							if (errors.length)
 								throw new Error(`CSV parsed with ${errors.length} error(s)`);
 							if (dbKeys.size === 0)

--- a/thunderstorm/frontend/src/main/modules/sync-manager/ModuleFE_SyncManager_CSV.ts
+++ b/thunderstorm/frontend/src/main/modules/sync-manager/ModuleFE_SyncManager_CSV.ts
@@ -25,7 +25,7 @@ export class ModuleFE_SyncManager_CSV_Class
 		const itemsToSync: any[] = [];
 		const errors: any[] = [];
 
-		await new Promise<void>(resolve => {
+		await new Promise<void>((resolve, reject) => {
 			const isEmulator = Thunder.getInstance().getConfig().label?.toLowerCase() === 'local';
 			const downloadRequestHeaders = isEmulator ? undefined : {[HeaderKey_ContentType]: 'text/csv'};
 			const finalConfig = config ? mergeObject({downloadRequestHeaders}, config) : {downloadRequestHeaders};
@@ -48,33 +48,54 @@ export class ModuleFE_SyncManager_CSV_Class
 					},
 
 					complete: async () => {
-						for(const dbKey of dbKeys) {
-							const items = itemsToSync.filter(item => item.dbKey === dbKey);
-							const module = modules[dbKey];
-							module.setDataStatus(DataStatus.UpdatingData);
-							// Get all docs to upsert
-							const documents = items.map(i => i.document);
+						try {
+							// Any parse error fails the whole sync — surfaced via the session
+							// error UI (ComponentValidateSessionV2) and clears the version key
+							// (ModuleFE_AdvisorSync.syncSnapshot catch), rather than silently
+							// committing partial data.
+							if (errors.length)
+								throw new Error(`CSV parsed with ${errors.length} error(s)`);
+							if (dbKeys.size === 0)
+								throw new Error('CSV parsed but no recognised dbKeys');
 
-							// Run upgrade processors on them from the module
-							await module.upgradeInstances(documents);
+							for (const dbKey of dbKeys) {
+								const items = itemsToSync.filter(item => item.dbKey === dbKey);
+								const module = modules[dbKey];
+								module.setDataStatus(DataStatus.UpdatingData);
+								// Get all docs to upsert
+								const documents = items.map(i => i.document);
 
-							// Upsert items to the idb
-							await module.IDB.syncIndexDb(documents);
-							await module.cache.load();
-							module.setDataStatus(DataStatus.ContainsData);
+								// Run upgrade processors on them from the module
+								await module.upgradeInstances(documents);
+
+								// Upsert items to the idb
+								await module.IDB.syncIndexDb(documents);
+								await module.cache.load();
+								module.setDataStatus(DataStatus.ContainsData);
+							}
+							const end = performance.now();
+							this.logInfo(`sync took ${((end - start) / 1000).toFixed(3)} seconds`);
+							resolve();
+						} catch (e) {
+							this.logError('CSV sync failed', e as Error);
+							reject(e);
 						}
-						const end = performance.now();
-						this.logInfo(`sync took ${((end - start) / 1000).toFixed(3)} seconds`);
-						if (errors.length)
-							this.logError('Parsed with errors', ...errors);
-						resolve();
 					},
 					...finalConfig,
 					error: (error: Error) => {
 						this.logError(`CSV Parsing failed`, error);
+						reject(error);
 					}
 				});
 		});
+	};
+
+	hasAnyData = async (): Promise<boolean> => {
+		for (const module of this.getModulesToSync()) {
+			if (await module.IDB.count() > 0)
+				return true;
+		}
+		return false;
 	};
 
 	readyAllModules = async () => {


### PR DESCRIPTION
## Module readiness / artifact-sync hardening

Fixes the class of bug where a module reports `DataStatus.ContainsData` while its cache/IDB is actually empty, so `AwaitModules` opens a gate and downstream components render (and crash) against empty data. Companion to the advisor-v5 change in quai-web that consumes this via the artifact sync.

### `syncFromCSVUrl` — fail loudly instead of hanging
The wrapping `Promise` had no `reject` in scope: a failed artifact download/parse never settled, hanging the caller forever (stuck loader). It now **rejects on any failure** — any papaparse row error, zero recognised `dbKeys`, and the papaparse `error` callback — so the failure propagates to the caller's error handling instead of silently stalling.

### `hasAnyData()` — status-neutral IDB probe (new)
A single global `IDB.count()` check across CSVSync modules. Reads counts without mutating any module status, so the artifact sync can detect an evicted IndexedDB **before** marking modules ready. Used by quai-web's `ModuleFE_AdvisorSync.syncSnapshot`.

### `performFullSync` — flip `UpdatingData` before clearing the cache
When `cleanIDBOnFullSync` is `false`, the status stayed `ContainsData` across the whole fetch, so the terminal `setDataStatus(ContainsData)` was a no-op that dispatched nothing — `AwaitModules` never re-derived and components kept rendering the just-cleared cache. Setting `UpdatingData` before the clear makes the final transition real (and dispatch) in both branches.

### `performNoSync` — require a non-empty cache before trusting `ContainsData`
The "already loaded, skip" early-return trusted the status alone. It now also requires `cache.all().length > 0`; otherwise it logs and falls through to reload from IDB, rather than trusting a status that claims data that isn't there.

## Commits
- `reject CSV sync on failure, add hasAnyData probe`
- `don't treat ContainsData as ready with an empty cache`

## Known follow-up (not in this PR)
A genuinely failed **APISync query** (`performFullSync`/`performDeltaSync` catch-and-log) still leaves the module short of `ContainsData` with no user-facing signal — an `AwaitModules` stalled/timeout state would close that. Tracked separately.
