### PR TITLE
Epic JWKS: ModuleBE_KMS for asymmetric signing

### DIFF
--- a/build-and-install/src/main/config/consts.ts
+++ b/build-and-install/src/main/config/consts.ts
@@ -1,8 +1,6 @@
 /**
  * Constants for file names and configuration keys used throughout the build system.
  */
-import {MemKey} from '@nu-art/ts-common/mem-storage/index';
-import {RuntimeProjectConfig} from './types/index.js';
 
 /** Version file name (version-app.json) */
 export const CONST_VersionApp = 'version-app.json';
@@ -41,5 +39,3 @@ export const CONST_DeployHostingDir = 'deploy-hosting';
 /** Build image temp directory name (build-image) */
 export const CONST_BuildImageDir = 'build-image';
 
-/** Memory storage key for packages configuration */
-export const MemKey_Packages = new MemKey<RuntimeProjectConfig>('bai-packages', true);

--- a/google-services/backend/__package.json
+++ b/google-services/backend/__package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@nu-art/ts-common": "?",
+    "@google-cloud/kms": "?",
     "@google-cloud/pubsub": "?",
     "@google-cloud/secret-manager": "?",
     "google-auth-library": "?",

--- a/google-services/backend/src/main/index.ts
+++ b/google-services/backend/src/main/index.ts
@@ -22,5 +22,6 @@ export * from './modules/ModuleBE_GoogleContacts.js';
 export * from './modules/ModuleBE_Auth.js';
 export * from './modules/ModuleBE_GooglePubSub.js';
 export * from './modules/ModuleBE_SecretManager.js';
+export * from './modules/ModuleBE_KMS.js';
 export * from './modules/ModuleBE_WhoAmI_GCP.js';
 

--- a/google-services/backend/src/main/modules/ModuleBE_KMS.ts
+++ b/google-services/backend/src/main/modules/ModuleBE_KMS.ts
@@ -14,8 +14,22 @@
  * limitations under the License.
  */
 
-import {ImplementationMissingException, Module, MUSTNeverHappenException, ThisShouldNotHappenException} from '@nu-art/ts-common';
+import {
+	ImplementationMissingException,
+	MissingDataException,
+	Module,
+	MUSTNeverHappenException,
+	ThisShouldNotHappenException
+} from '@nu-art/ts-common';
 import {KeyManagementServiceClient, protos} from '@google-cloud/kms';
+
+/** gRPC status codes used by Cloud KMS (google.rpc.Code). */
+const GrpcCode_NotFound = 5;
+const GrpcCode_AlreadyExists = 6;
+
+function isGrpcCode(err: unknown, code: number): boolean {
+	return typeof err === 'object' && err !== null && 'code' in err && (err as { code: unknown }).code === code;
+}
 
 export type ModuleBE_KMS_Config = {
 	projectId?: string;
@@ -90,26 +104,25 @@ export class ModuleBE_KMS_Class
 		return this.client.cryptoKeyVersionPath(ctx.projectId, ctx.locationId, keyRingId, keyId, versionId);
 	}
 
-	/** Create key ring if it does not exist. Idempotent. */
+	/** Create key ring if it does not exist. Idempotent under concurrency (swallows ALREADY_EXISTS). */
 	public ensureKeyRing = async (keyRingId: string, context?: KMSContext): Promise<void> => {
 		const ctx = this.resolveContext(context);
 		const parent = this.getParent(ctx);
 		try {
 			await this.client.getKeyRing({name: this.keyRingPath(ctx, keyRingId)});
 			return;
-		} catch (err: any) {
-			if (err.code !== 5) // NOT_FOUND
-				throw new ThisShouldNotHappenException(`Failed to get key ring ${keyRingId}`, err);
+		} catch (err: unknown) {
+			if (!isGrpcCode(err, GrpcCode_NotFound))
+				throw new ThisShouldNotHappenException(`Failed to get key ring ${keyRingId}`, err instanceof Error ? err : undefined);
 		}
 
-		await this.client.createKeyRing({
-			parent,
-			keyRingId,
-			keyRing: {}
-		});
+		await this.createIgnoringAlreadyExists(
+			() => this.client.createKeyRing({parent, keyRingId, keyRing: {}}),
+			`key ring ${keyRingId}`
+		);
 	};
 
-	/** Create crypto key with given purpose and algorithm if it does not exist. Idempotent. */
+	/** Create crypto key with given purpose and algorithm if it does not exist. Idempotent under concurrency. */
 	public ensureCryptoKey = async (keyRingId: string, keyId: string, options: EnsureCryptoKeyOptions, context?: KMSContext): Promise<void> => {
 		const ctx = this.resolveContext(context);
 		const parent = this.keyRingPath(ctx, keyRingId);
@@ -120,24 +133,57 @@ export class ModuleBE_KMS_Class
 				filter: 'state=ENABLED'
 			});
 			if (versions.length === 0)
-				await this.client.createCryptoKeyVersion({
-					parent: this.cryptoKeyPath(ctx, keyRingId, keyId),
-					cryptoKeyVersion: {}
-				});
+				await this.createIgnoringAlreadyExists(
+					() => this.client.createCryptoKeyVersion({
+						parent: this.cryptoKeyPath(ctx, keyRingId, keyId),
+						cryptoKeyVersion: {}
+					}),
+					`key version ${keyRingId}/${keyId}`
+				);
 			return;
-		} catch (err: any) {
-			if (err.code !== 5)
-				throw new ThisShouldNotHappenException(`Failed to get crypto key ${keyRingId}/${keyId}`, err);
+		} catch (err: unknown) {
+			if (!isGrpcCode(err, GrpcCode_NotFound))
+				throw new ThisShouldNotHappenException(`Failed to get crypto key ${keyRingId}/${keyId}`, err instanceof Error ? err : undefined);
 		}
-		await this.client.createCryptoKey({
-			parent,
-			cryptoKeyId: keyId,
-			cryptoKey: {
-				purpose: options.purpose,
-				versionTemplate: {algorithm: options.algorithm}
-			}
-		});
+
+		await this.createIgnoringAlreadyExists(
+			() => this.client.createCryptoKey({
+				parent,
+				cryptoKeyId: keyId,
+				cryptoKey: {
+					purpose: options.purpose,
+					versionTemplate: {algorithm: options.algorithm}
+				}
+			}),
+			`crypto key ${keyRingId}/${keyId}`
+		);
 	};
+
+	/** Fail if the crypto key is missing. Used to block a JWKS flip before rings exist. */
+	public assertCryptoKeyExists = async (keyRingId: string, keyId: string, context?: KMSContext): Promise<void> => {
+		const ctx = this.resolveContext(context);
+		try {
+			await this.client.getCryptoKey({name: this.cryptoKeyPath(ctx, keyRingId, keyId)});
+		} catch (err: unknown) {
+			if (isGrpcCode(err, GrpcCode_NotFound))
+				throw new MissingDataException(`KMS key ${keyRingId}/${keyId} does not exist`);
+
+			throw new ThisShouldNotHappenException(`Failed to get crypto key ${keyRingId}/${keyId}`, err instanceof Error ? err : undefined);
+		}
+	};
+
+	private async createIgnoringAlreadyExists(create: () => Promise<unknown>, label: string): Promise<void> {
+		try {
+			await create();
+		} catch (err: unknown) {
+			if (isGrpcCode(err, GrpcCode_AlreadyExists)) {
+				this.logDebug(`create raced, ALREADY_EXISTS treated as success — ${label}`);
+				return;
+			}
+
+			throw new ThisShouldNotHappenException(`Failed to create ${label}`, err instanceof Error ? err : undefined);
+		}
+	}
 
 	/** Create a new key version for rotation. Old versions remain until manually destroyed. */
 	public createNewKeyVersion = async (keyRingId: string, keyId: string, context?: KMSContext): Promise<string> => {

--- a/google-services/backend/src/main/modules/ModuleBE_KMS.ts
+++ b/google-services/backend/src/main/modules/ModuleBE_KMS.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Module, MUSTNeverHappenException, ThisShouldNotHappenException} from '@nu-art/ts-common';
+import {ImplementationMissingException, Module, MUSTNeverHappenException, ThisShouldNotHappenException} from '@nu-art/ts-common';
 import {KeyManagementServiceClient} from '@google-cloud/kms';
 
 export type ModuleBE_KMS_Config = {
@@ -63,7 +63,8 @@ export class ModuleBE_KMS_Class
 	private get parent() {
 		const {projectId, locationId} = this.config;
 		if (!projectId)
-			throw new MUSTNeverHappenException('ModuleBE_KMS requires config.projectId');
+			throw new ImplementationMissingException('ModuleBE_KMS requires config.projectId');
+
 		return this.client.locationPath(projectId, locationId ?? DefaultLocationId);
 	}
 

--- a/google-services/backend/src/main/modules/ModuleBE_KMS.ts
+++ b/google-services/backend/src/main/modules/ModuleBE_KMS.ts
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2020 Yair bcm
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Module, MUSTNeverHappenException, ThisShouldNotHappenException} from '@nu-art/ts-common';
+import {KeyManagementServiceClient} from '@google-cloud/kms';
+
+export type ModuleBE_KMS_Config = {
+	projectId: string;
+	locationId?: string;
+};
+
+const DefaultLocationId = 'us-east1';
+
+/** Cloud KMS CryptoKey.CryptoKeyPurpose enum values (for callers). */
+export const CryptoKeyPurpose = {
+	ASYMMETRIC_SIGN: 1,
+	ASYMMETRIC_DECRYPT: 5,
+	MAC: 9,
+	CRYPTO_KEY_PURPOSE_UNSPECIFIED: 0
+} as const;
+
+/** Cloud KMS CryptoKeyVersion.CryptoKeyVersionAlgorithm enum values (for callers). */
+export const CryptoKeyVersionAlgorithm = {
+	RSA_SIGN_PKCS1_2048_SHA256: 5,
+	RSA_SIGN_PKCS1_3072_SHA256: 6,
+	RSA_SIGN_PKCS1_4096_SHA256: 7
+	// add others as needed
+} as const;
+
+export type EnsureCryptoKeyOptions = {
+	purpose: number;
+	algorithm: number;
+};
+
+/** Digest for asymmetric sign: SHA-256 of the data (32 bytes). */
+export type KMSDigest = {
+	sha256: Buffer;
+};
+
+export class ModuleBE_KMS_Class
+	extends Module<ModuleBE_KMS_Config> {
+	private client!: KeyManagementServiceClient;
+
+	protected init() {
+		super.init();
+		this.setDefaultConfig({locationId: DefaultLocationId} as Partial<ModuleBE_KMS_Config>);
+		this.client = new KeyManagementServiceClient();
+	}
+
+	private get parent() {
+		const {projectId, locationId} = this.config;
+		if (!projectId)
+			throw new MUSTNeverHappenException('ModuleBE_KMS requires config.projectId');
+		return this.client.locationPath(projectId, locationId ?? DefaultLocationId);
+	}
+
+	private keyRingPath(keyRingId: string): string {
+		return this.client.keyRingPath(this.config.projectId!, this.config.locationId ?? DefaultLocationId, keyRingId);
+	}
+
+	private cryptoKeyPath(keyRingId: string, keyId: string): string {
+		return this.client.cryptoKeyPath(
+			this.config.projectId!,
+			this.config.locationId ?? DefaultLocationId,
+			keyRingId,
+			keyId
+		);
+	}
+
+	private cryptoKeyVersionPath(keyRingId: string, keyId: string, versionId: string): string {
+		return this.client.cryptoKeyVersionPath(
+			this.config.projectId!,
+			this.config.locationId ?? DefaultLocationId,
+			keyRingId,
+			keyId,
+			versionId
+		);
+	}
+
+	/** Create key ring if it does not exist. Idempotent. */
+	public ensureKeyRing = async (keyRingId: string): Promise<void> => {
+		const parent = this.parent;
+		try {
+			await this.client.getKeyRing({name: this.keyRingPath(keyRingId)});
+			return;
+		} catch (err: any) {
+			if (err.code !== 5) // NOT_FOUND
+				throw new ThisShouldNotHappenException(`Failed to get key ring ${keyRingId}`, err);
+		}
+		await this.client.createKeyRing({
+			parent,
+			keyRingId,
+			keyRing: {}
+		});
+	};
+
+	/** Create crypto key with given purpose and algorithm if it does not exist. Idempotent. */
+	public ensureCryptoKey = async (keyRingId: string, keyId: string, options: EnsureCryptoKeyOptions): Promise<void> => {
+		const parent = this.keyRingPath(keyRingId);
+		try {
+			await this.client.getCryptoKey({name: this.cryptoKeyPath(keyRingId, keyId)});
+			const [versions] = await this.client.listCryptoKeyVersions({
+				parent: this.cryptoKeyPath(keyRingId, keyId),
+				filter: 'state=ENABLED'
+			});
+			if (versions.length === 0)
+				await this.client.createCryptoKeyVersion({
+					parent: this.cryptoKeyPath(keyRingId, keyId),
+					cryptoKeyVersion: {}
+				});
+			return;
+		} catch (err: any) {
+			if (err.code !== 5)
+				throw new ThisShouldNotHappenException(`Failed to get crypto key ${keyRingId}/${keyId}`, err);
+		}
+		await this.client.createCryptoKey({
+			parent,
+			cryptoKeyId: keyId,
+			cryptoKey: {
+				purpose: options.purpose,
+				versionTemplate: {algorithm: options.algorithm}
+			}
+		});
+	};
+
+	/** Create a new key version for rotation. Old versions remain until manually destroyed. */
+	public createNewKeyVersion = async (keyRingId: string, keyId: string): Promise<string> => {
+		const [version] = await this.client.createCryptoKeyVersion({
+			parent: this.cryptoKeyPath(keyRingId, keyId),
+			cryptoKeyVersion: {}
+		});
+		const versionId = version.name?.split('/').pop();
+		if (!versionId)
+			throw new MUSTNeverHappenException(`Missing version id in createCryptoKeyVersion response`);
+		return versionId;
+	};
+
+	/** List enabled key versions (newest first). */
+	public listKeyVersions = async (keyRingId: string, keyId: string): Promise<Array<{ name?: string | null }>> => {
+		const [versions] = await this.client.listCryptoKeyVersions({
+			parent: this.cryptoKeyPath(keyRingId, keyId),
+			filter: 'state=ENABLED'
+		});
+		// Sort by version number descending (newest first)
+		return versions.sort((a, b) => {
+			const aVer = parseInt(a.name?.split('/').pop() ?? '0', 10);
+			const bVer = parseInt(b.name?.split('/').pop() ?? '0', 10);
+			return bVer - aVer;
+		});
+	};
+
+	/** Get PEM-encoded public key for a key version. */
+	public getPublicKey = async (keyRingId: string, keyId: string, versionId: string): Promise<string> => {
+		const [pub] = await this.client.getPublicKey({
+			name: this.cryptoKeyVersionPath(keyRingId, keyId, versionId)
+		});
+		if (!pub.pem)
+			throw new MUSTNeverHappenException(`Public key has no pem for ${keyRingId}/${keyId}/${versionId}`);
+		return pub.pem;
+	};
+
+	/** Sign a digest with the given key version. Digest must be SHA-256 (32 bytes). */
+	public asymmetricSign = async (keyRingId: string, keyId: string, versionId: string, digest: KMSDigest): Promise<Buffer> => {
+		const [response] = await this.client.asymmetricSign({
+			name: this.cryptoKeyVersionPath(keyRingId, keyId, versionId),
+			digest
+		});
+		if (!response.signature)
+			throw new MUSTNeverHappenException(`asymmetricSign returned no signature`);
+		return Buffer.isBuffer(response.signature) ? response.signature : Buffer.from(response.signature as Uint8Array);
+	};
+}
+
+export const ModuleBE_KMS = new ModuleBE_KMS_Class();

--- a/google-services/backend/src/main/modules/ModuleBE_KMS.ts
+++ b/google-services/backend/src/main/modules/ModuleBE_KMS.ts
@@ -15,30 +15,27 @@
  */
 
 import {ImplementationMissingException, Module, MUSTNeverHappenException, ThisShouldNotHappenException} from '@nu-art/ts-common';
-import {KeyManagementServiceClient} from '@google-cloud/kms';
+import {KeyManagementServiceClient, protos} from '@google-cloud/kms';
 
 export type ModuleBE_KMS_Config = {
-	projectId: string;
+	projectId?: string;
 	locationId?: string;
 };
 
-const DefaultLocationId = 'us-east1';
+/** Optional per-request context for project/location; takes precedence over module config and env. */
+export type KMSContext = {
+	projectId?: string;
+	locationId?: string;
+};
 
-/** Cloud KMS CryptoKey.CryptoKeyPurpose enum values (for callers). */
-export const CryptoKeyPurpose = {
-	ASYMMETRIC_SIGN: 1,
-	ASYMMETRIC_DECRYPT: 5,
-	MAC: 9,
-	CRYPTO_KEY_PURPOSE_UNSPECIFIED: 0
-} as const;
+/** Default KMS location when not provided via context or config (GCP multi-region "global"). */
+const DefaultLocationId = 'global';
 
-/** Cloud KMS CryptoKeyVersion.CryptoKeyVersionAlgorithm enum values (for callers). */
-export const CryptoKeyVersionAlgorithm = {
-	RSA_SIGN_PKCS1_2048_SHA256: 5,
-	RSA_SIGN_PKCS1_3072_SHA256: 6,
-	RSA_SIGN_PKCS1_4096_SHA256: 7
-	// add others as needed
-} as const;
+/** Re-export KMS purpose enum from package (use for ensureCryptoKey etc.). */
+export const CryptoKeyPurpose = protos.google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose;
+
+/** Re-export KMS algorithm enum from package (use for ensureCryptoKey etc.). */
+export const CryptoKeyVersionAlgorithm = protos.google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm;
 
 export type EnsureCryptoKeyOptions = {
 	purpose: number;
@@ -56,51 +53,55 @@ export class ModuleBE_KMS_Class
 
 	protected init() {
 		super.init();
-		this.setDefaultConfig({locationId: DefaultLocationId} as Partial<ModuleBE_KMS_Config>);
 		this.client = new KeyManagementServiceClient();
 	}
 
-	private get parent() {
-		const {projectId, locationId} = this.config;
+	private resolveContext(requestContext?: KMSContext): { projectId: string; locationId: string } {
+		const projectId = requestContext?.projectId
+			?? this.config.projectId
+			?? process.env.GCP_PROJECT_ID
+			?? process.env.GCLOUD_PROJECT;
+
 		if (!projectId)
-			throw new ImplementationMissingException('ModuleBE_KMS requires config.projectId');
+			throw new ImplementationMissingException(
+				'KMS projectId not provided via request context, module config, or env (GCP_PROJECT_ID / GCLOUD_PROJECT)'
+			);
 
-		return this.client.locationPath(projectId, locationId ?? DefaultLocationId);
+		const locationId = requestContext?.locationId
+			?? this.config.locationId
+			?? DefaultLocationId;
+
+		return { projectId, locationId };
 	}
 
-	private keyRingPath(keyRingId: string): string {
-		return this.client.keyRingPath(this.config.projectId!, this.config.locationId ?? DefaultLocationId, keyRingId);
+	private getParent(ctx: { projectId: string; locationId: string }): string {
+		return this.client.locationPath(ctx.projectId, ctx.locationId);
 	}
 
-	private cryptoKeyPath(keyRingId: string, keyId: string): string {
-		return this.client.cryptoKeyPath(
-			this.config.projectId!,
-			this.config.locationId ?? DefaultLocationId,
-			keyRingId,
-			keyId
-		);
+	private keyRingPath(ctx: { projectId: string; locationId: string }, keyRingId: string): string {
+		return this.client.keyRingPath(ctx.projectId, ctx.locationId, keyRingId);
 	}
 
-	private cryptoKeyVersionPath(keyRingId: string, keyId: string, versionId: string): string {
-		return this.client.cryptoKeyVersionPath(
-			this.config.projectId!,
-			this.config.locationId ?? DefaultLocationId,
-			keyRingId,
-			keyId,
-			versionId
-		);
+	private cryptoKeyPath(ctx: { projectId: string; locationId: string }, keyRingId: string, keyId: string): string {
+		return this.client.cryptoKeyPath(ctx.projectId, ctx.locationId, keyRingId, keyId);
+	}
+
+	private cryptoKeyVersionPath(ctx: { projectId: string; locationId: string }, keyRingId: string, keyId: string, versionId: string): string {
+		return this.client.cryptoKeyVersionPath(ctx.projectId, ctx.locationId, keyRingId, keyId, versionId);
 	}
 
 	/** Create key ring if it does not exist. Idempotent. */
-	public ensureKeyRing = async (keyRingId: string): Promise<void> => {
-		const parent = this.parent;
+	public ensureKeyRing = async (keyRingId: string, context?: KMSContext): Promise<void> => {
+		const ctx = this.resolveContext(context);
+		const parent = this.getParent(ctx);
 		try {
-			await this.client.getKeyRing({name: this.keyRingPath(keyRingId)});
+			await this.client.getKeyRing({name: this.keyRingPath(ctx, keyRingId)});
 			return;
 		} catch (err: any) {
 			if (err.code !== 5) // NOT_FOUND
 				throw new ThisShouldNotHappenException(`Failed to get key ring ${keyRingId}`, err);
 		}
+
 		await this.client.createKeyRing({
 			parent,
 			keyRingId,
@@ -109,17 +110,18 @@ export class ModuleBE_KMS_Class
 	};
 
 	/** Create crypto key with given purpose and algorithm if it does not exist. Idempotent. */
-	public ensureCryptoKey = async (keyRingId: string, keyId: string, options: EnsureCryptoKeyOptions): Promise<void> => {
-		const parent = this.keyRingPath(keyRingId);
+	public ensureCryptoKey = async (keyRingId: string, keyId: string, options: EnsureCryptoKeyOptions, context?: KMSContext): Promise<void> => {
+		const ctx = this.resolveContext(context);
+		const parent = this.keyRingPath(ctx, keyRingId);
 		try {
-			await this.client.getCryptoKey({name: this.cryptoKeyPath(keyRingId, keyId)});
+			await this.client.getCryptoKey({name: this.cryptoKeyPath(ctx, keyRingId, keyId)});
 			const [versions] = await this.client.listCryptoKeyVersions({
-				parent: this.cryptoKeyPath(keyRingId, keyId),
+				parent: this.cryptoKeyPath(ctx, keyRingId, keyId),
 				filter: 'state=ENABLED'
 			});
 			if (versions.length === 0)
 				await this.client.createCryptoKeyVersion({
-					parent: this.cryptoKeyPath(keyRingId, keyId),
+					parent: this.cryptoKeyPath(ctx, keyRingId, keyId),
 					cryptoKeyVersion: {}
 				});
 			return;
@@ -138,9 +140,10 @@ export class ModuleBE_KMS_Class
 	};
 
 	/** Create a new key version for rotation. Old versions remain until manually destroyed. */
-	public createNewKeyVersion = async (keyRingId: string, keyId: string): Promise<string> => {
+	public createNewKeyVersion = async (keyRingId: string, keyId: string, context?: KMSContext): Promise<string> => {
+		const ctx = this.resolveContext(context);
 		const [version] = await this.client.createCryptoKeyVersion({
-			parent: this.cryptoKeyPath(keyRingId, keyId),
+			parent: this.cryptoKeyPath(ctx, keyRingId, keyId),
 			cryptoKeyVersion: {}
 		});
 		const versionId = version.name?.split('/').pop();
@@ -150,9 +153,10 @@ export class ModuleBE_KMS_Class
 	};
 
 	/** List enabled key versions (newest first). */
-	public listKeyVersions = async (keyRingId: string, keyId: string): Promise<Array<{ name?: string | null }>> => {
+	public listKeyVersions = async (keyRingId: string, keyId: string, context?: KMSContext): Promise<Array<{ name?: string | null }>> => {
+		const ctx = this.resolveContext(context);
 		const [versions] = await this.client.listCryptoKeyVersions({
-			parent: this.cryptoKeyPath(keyRingId, keyId),
+			parent: this.cryptoKeyPath(ctx, keyRingId, keyId),
 			filter: 'state=ENABLED'
 		});
 		// Sort by version number descending (newest first)
@@ -164,9 +168,10 @@ export class ModuleBE_KMS_Class
 	};
 
 	/** Get PEM-encoded public key for a key version. */
-	public getPublicKey = async (keyRingId: string, keyId: string, versionId: string): Promise<string> => {
+	public getPublicKey = async (keyRingId: string, keyId: string, versionId: string, context?: KMSContext): Promise<string> => {
+		const ctx = this.resolveContext(context);
 		const [pub] = await this.client.getPublicKey({
-			name: this.cryptoKeyVersionPath(keyRingId, keyId, versionId)
+			name: this.cryptoKeyVersionPath(ctx, keyRingId, keyId, versionId)
 		});
 		if (!pub.pem)
 			throw new MUSTNeverHappenException(`Public key has no pem for ${keyRingId}/${keyId}/${versionId}`);
@@ -174,9 +179,10 @@ export class ModuleBE_KMS_Class
 	};
 
 	/** Sign a digest with the given key version. Digest must be SHA-256 (32 bytes). */
-	public asymmetricSign = async (keyRingId: string, keyId: string, versionId: string, digest: KMSDigest): Promise<Buffer> => {
+	public asymmetricSign = async (keyRingId: string, keyId: string, versionId: string, digest: KMSDigest, context?: KMSContext): Promise<Buffer> => {
+		const ctx = this.resolveContext(context);
 		const [response] = await this.client.asymmetricSign({
-			name: this.cryptoKeyVersionPath(keyRingId, keyId, versionId),
+			name: this.cryptoKeyVersionPath(ctx, keyRingId, keyId, versionId),
 			digest
 		});
 		if (!response.signature)


### PR DESCRIPTION
## Summary
- Add generic `ModuleBE_KMS` wrapper (`ensureKeyRing`, `ensureCryptoKey`, `listKeyVersions`, `getPublicKey`, `asymmetricSign`, etc.)
- Supports Epic JWKS cutover in KM (public JWKS from KMS) and EM (JWT signing via KMS)

## Test plan
- [ ] KM `create-epic-keyrings` action creates the three keyrings in the target GCP project
- [ ] KM `/v1/jwks/<keyring>` returns JWKS with `kid` = `keyring:version`
- [ ] EM JWKS auth path can sign via this module (covered in EM PR)